### PR TITLE
Use fifo_sink module

### DIFF
--- a/cdl/dbg_master_fifo_sink.cdl
+++ b/cdl/dbg_master_fifo_sink.cdl
@@ -22,6 +22,7 @@
 include "debug.h"
 include "fifo_sink.h"
 include "fifo_status.h"
+include "fifo_modules.h"
 
 /*a Types */
 /*t t_dbg_if_action
@@ -55,17 +56,11 @@ typedef enum [4] {
     fifo_ctrl_action_none,
     fifo_ctrl_action_start,
     fifo_ctrl_action_do_status,
-    fifo_ctrl_action_read_status,
     fifo_ctrl_action_capture_pop_req,
-    fifo_ctrl_action_wait_for_pop_data_valid,
-    fifo_ctrl_action_pop_capture_data,
-    fifo_ctrl_action_read_data,
-    fifo_ctrl_action_read_data_gap,
-    fifo_ctrl_action_read_data_gap_last_more_words,
-    fifo_ctrl_action_read_data_gap_last,
-    fifo_ctrl_action_complete_okay         "Enter complete state with okay completion",
-    fifo_ctrl_action_complete_errored      "Enter complete state with errored completion",
-    fifo_ctrl_action_complete_poll_failed  "Enter complete state with polling failed completion",
+    fifo_ctrl_action_request_next_data,
+    fifo_ctrl_action_take_next_data,
+    fifo_ctrl_action_take_last_data,
+    fifo_ctrl_action_complete "Completed; the combs 'poll_failed' and 'errored' indicate failures"
 } t_fifo_ctrl_action;
 
 /*t t_fifo_ctrl_fsm_state
@@ -78,19 +73,15 @@ typedef fsm {
     }     "Fifo_Ctrl idle - waiting to start";
     fifo_ctrl_fsm_wait_for_op {
         fifo_ctrl_fsm_idle,
-        fifo_ctrl_fsm_reading_status,
+        fifo_ctrl_fsm_request_next_data
+    }     "Waiting for a byte-code op - or end of data - will send initial request to FIFO sink";
+    fifo_ctrl_fsm_request_next_data {
+        fifo_ctrl_fsm_wait_for_data,
         fifo_ctrl_fsm_data
-    }     "Waiting for a byte-code op - or end of data";
-    fifo_ctrl_fsm_reading_status {
-        fifo_ctrl_fsm_wait_for_op
-    }     "Capturing the fifo_status as 32-bit data, then back to the next op";
-    fifo_ctrl_fsm_req_pop {
-        fifo_ctrl_fsm_wait_for_pop_data_valid,
-        fifo_ctrl_fsm_data
-    }     "Requesting pop of data";
-    fifo_ctrl_fsm_wait_for_pop_data_valid {
-        fifo_ctrl_fsm_data
-    }     "Requesting pop of data";
+    }     "Sending read_data action to FIFO sink";
+    fifo_ctrl_fsm_wait_for_data {
+        fifo_ctrl_fsm_request_next_data
+    }     "Waiting for FIFO sink to provide resp.valid";
     fifo_ctrl_fsm_data {
         fifo_ctrl_fsm_data_gap
     }     "";
@@ -110,11 +101,6 @@ typedef fsm {
 typedef struct {
     t_fifo_ctrl_fsm_state fsm_state   "Fifo_Ctrl FSM state machine state";
     bit err_on_empty "Asserted if pop of empty fifo shoud fail poll; clear if it should just stop"; 
-    bit[6] count;
-    bit[6] byte_count;
-    bit[16] word_count;
-    bit[32][8] data;
-    t_fifo_status fifo_status;
 } t_fifo_ctrl_state;
 
 /*t t_fifo_ctrl_combs
@@ -139,22 +125,10 @@ typedef struct {
     bit[2] bytes_consumed;
     bit has_required_bytes;
 
-    bit[3] read_data_bytes_valid;
-
-    bit pop_fifo;
     bit completed;
     bit poll_failed;
     bit errored;
 } t_fifo_ctrl_combs;
-
-/*t t_fifo_ctrl_data
- *
- * Data to be returned in the dbg response
- */
-typedef struct {
-    bit[32] data;
-    bit[3] bytes_valid;
-} t_fifo_ctrl_data;
 
 /*a Module */
 module dbg_master_fifo_sink( clock clk,
@@ -194,10 +168,12 @@ Debug script is opcode of (2,6) [24]:
     comb t_dbg_if_action dbg_if_action;
     clocked t_dbg_if_state dbg_if_state = {*=0};
 
-    comb t_fifo_ctrl_combs           fifo_ctrl_combs       "Combinatorial decode of ROM state";
-    clocked t_fifo_ctrl_state        fifo_ctrl_state={*=0}                                      "State of the ROM-side; request and ROM access";
+    comb t_fifo_ctrl_combs    fifo_ctrl_combs       "Combinatorial decode of ROM state";
+    clocked t_fifo_ctrl_state fifo_ctrl_state={*=0} "State of the ROM-side; request and ROM access";
 
-    clocked t_fifo_ctrl_data fifo_ctrl_data = {*=0};
+    comb t_fifo_sink_ctrl fifo_sink_ctrl;
+    net bit pop_fifo;
+    net t_fifo_sink_response fifo_resp;
 
     /*b Script interface logic */
     script_interface_logic """
@@ -257,8 +233,12 @@ Debug script is opcode of (2,6) [24]:
             dbg_master_resp.resp_type = dbg_resp_running;
         }
         dbg_master_resp.bytes_consumed = bundle(2b0, fifo_ctrl_combs.bytes_consumed);
-        dbg_master_resp.bytes_valid = fifo_ctrl_data.bytes_valid;
-        dbg_master_resp.data        = fifo_ctrl_data.data;
+        dbg_master_resp.bytes_valid = fifo_resp.bytes_valid;
+        dbg_master_resp.data        = fifo_resp.data;
+        if (!fifo_resp.valid) {
+            dbg_master_resp.bytes_valid = 0;
+            dbg_master_resp.data        = 0;
+        }
 
         /*b All done */
     }
@@ -293,7 +273,6 @@ Debug script is opcode of (2,6) [24]:
         /*b Determine script action */
         fifo_ctrl_combs.action = fifo_ctrl_action_none;
         fifo_ctrl_combs.bytes_consumed = 0;
-        fifo_ctrl_combs.pop_fifo = 0;
         full_switch (fifo_ctrl_state.fsm_state) {
         case fifo_ctrl_fsm_idle: {
             if (dbg_if_action == dbg_if_action_start) {
@@ -305,161 +284,100 @@ Debug script is opcode of (2,6) [24]:
                 if (fifo_ctrl_combs.opcode_is_status) {
                     fifo_ctrl_combs.action = fifo_ctrl_action_do_status;
                     fifo_ctrl_combs.bytes_consumed = fifo_ctrl_combs.bytes_required;
-                } elsif (fifo_ctrl_state.fifo_status.empty) {
-                    fifo_ctrl_combs.bytes_consumed = fifo_ctrl_combs.bytes_required;
-                    fifo_ctrl_combs.completed = 1;
-                    if (fifo_ctrl_combs.err_on_empty) {
-                        fifo_ctrl_combs.action = fifo_ctrl_action_complete_poll_failed;
-                        fifo_ctrl_combs.poll_failed = 1;
-                    }
                 } else {
-                    fifo_ctrl_combs.action = fifo_ctrl_action_capture_pop_req;
                     fifo_ctrl_combs.bytes_consumed = fifo_ctrl_combs.bytes_required;
+                    fifo_sink_ctrl.action = fifo_sink_action_idle;
+                    fifo_sink_ctrl.set_counts = 0;
+                    fifo_sink_ctrl.byte_count = 0;
+                    fifo_sink_ctrl.word_count = 0;
+                    fifo_ctrl_combs.action = fifo_ctrl_action_capture_pop_req;
+                    if (fifo_ctrl_combs.err_on_empty) {
+                    }
                 }
             } elsif (dbg_if_state.data_is_last) {
                 if (dbg_if_state.num_data_valid == 0) {
-                    fifo_ctrl_combs.completed = 1;
                     fifo_ctrl_combs.errored = 0;
-                    fifo_ctrl_combs.action = fifo_ctrl_action_complete_okay;
+                    fifo_ctrl_combs.action = fifo_ctrl_action_complete;
                 } else {
-                    fifo_ctrl_combs.completed = 1;
                     fifo_ctrl_combs.errored = 1;
-                    fifo_ctrl_combs.action = fifo_ctrl_action_complete_errored;
+                    fifo_ctrl_combs.action = fifo_ctrl_action_complete;
                 }
             }
         }
-        case fifo_ctrl_fsm_reading_status: {
-            fifo_ctrl_combs.action = fifo_ctrl_action_read_status;
-        }
-        case fifo_ctrl_fsm_req_pop: {
-            fifo_ctrl_combs.pop_fifo = 1;
-            if (pop_rdy) {
-                fifo_ctrl_combs.action = fifo_ctrl_action_wait_for_pop_data_valid;
-                if (data_valid) {
-                    fifo_ctrl_combs.action = fifo_ctrl_action_pop_capture_data;
+        case fifo_ctrl_fsm_wait_for_data: {
+            if (fifo_resp.valid) {
+                fifo_ctrl_combs.action = fifo_ctrl_action_take_next_data;
+                if (fifo_resp.last_word) {
+                    fifo_ctrl_combs.action = fifo_ctrl_action_take_last_data;
+                }
+                if (fifo_resp.empty) {
+                    fifo_ctrl_combs.action = fifo_ctrl_action_complete;
+                    fifo_ctrl_combs.poll_failed = fifo_ctrl_state.err_on_empty;
                 }
             }
         }
-        case fifo_ctrl_fsm_wait_for_pop_data_valid: {
-            if (data_valid) {
-                fifo_ctrl_combs.action = fifo_ctrl_action_pop_capture_data;
-            }
+        case fifo_ctrl_fsm_request_next_data: {
+            fifo_ctrl_combs.action = fifo_ctrl_action_request_next_data;
         }
-        case fifo_ctrl_fsm_data: {
-            fifo_ctrl_combs.action = fifo_ctrl_action_read_data;
-        }
-        case fifo_ctrl_fsm_data_gap: {
-            fifo_ctrl_combs.action = fifo_ctrl_action_read_data_gap;
-            if (fifo_ctrl_state.count < 4) {
-                if (fifo_ctrl_state.word_count == 0) {
-                    fifo_ctrl_combs.action = fifo_ctrl_action_read_data_gap_last;
-                } elsif (fifo_ctrl_state.fifo_status.empty) {
-                    fifo_ctrl_combs.completed = 1;
-                    fifo_ctrl_combs.action = fifo_ctrl_action_complete_okay;
-                    if (fifo_ctrl_state.err_on_empty) {
-                        fifo_ctrl_combs.poll_failed = 1;
-                        fifo_ctrl_combs.action = fifo_ctrl_action_complete_poll_failed;
-                    }
-                } else {
-                    fifo_ctrl_combs.action = fifo_ctrl_action_read_data_gap_last_more_words;
-                }
-            }
-        }
-        }
-        fifo_ctrl_combs.read_data_bytes_valid = 4;
-        if (fifo_ctrl_state.count < 4) {
-            fifo_ctrl_combs.read_data_bytes_valid = fifo_ctrl_state.count[3;0]+1;
         }
 
-        fifo_ctrl_data.bytes_valid <= 0;
+        fifo_sink_ctrl.action = fifo_sink_action_idle;
+        fifo_sink_ctrl.set_counts = 0;
+        fifo_sink_ctrl.byte_count = 0;
+        fifo_sink_ctrl.word_count = 0;
         full_switch (fifo_ctrl_combs.action) {
         case fifo_ctrl_action_start: {
             fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_op;
         }
         case fifo_ctrl_action_do_status: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_reading_status;
-        }
-        case fifo_ctrl_action_read_status: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_op;
-            fifo_ctrl_data.bytes_valid <= 4;
-            fifo_ctrl_data.data <=  bundle( fifo_ctrl_state.fifo_status.spaces_available[14;0],
-                                            fifo_ctrl_state.fifo_status.entries_full[14;0],
-                                            fifo_ctrl_state.fifo_status.overflowed,
-                                            fifo_ctrl_state.fifo_status.underflowed,
-                                            fifo_ctrl_state.fifo_status.full,
-                                            fifo_ctrl_state.fifo_status.empty );
-            if (fifo_ctrl_state.fifo_status.spaces_available >= 0x4000) {
-                fifo_ctrl_data.data[14;18] <= -1;
-            }
-            if (fifo_ctrl_state.fifo_status.entries_full >= 0x4000) {
-                fifo_ctrl_data.data[14;4] <= -1;
-            }
-                                           
+            fifo_sink_ctrl.action = fifo_sink_action_get_status;
+            fifo_ctrl_state.err_on_empty <= 0;
+            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_data;
         }
         case fifo_ctrl_action_capture_pop_req: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_req_pop;
+            fifo_sink_ctrl.action = fifo_sink_action_read_data;
+            fifo_sink_ctrl.set_counts = 1;
+            fifo_sink_ctrl.byte_count = fifo_ctrl_combs.opcode_data_size;
+            fifo_sink_ctrl.word_count = fifo_ctrl_combs.num_data;
             fifo_ctrl_state.err_on_empty <= fifo_ctrl_combs.err_on_empty;
-            fifo_ctrl_state.count <= fifo_ctrl_combs.opcode_data_size;
-            fifo_ctrl_state.byte_count <= fifo_ctrl_combs.opcode_data_size;
-            fifo_ctrl_state.word_count <= fifo_ctrl_combs.num_data;
+            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_data;
         }
-        case fifo_ctrl_action_wait_for_pop_data_valid: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_pop_data_valid;
+        case fifo_ctrl_action_request_next_data: {
+            fifo_sink_ctrl.action = fifo_sink_action_read_data;
+            fifo_sink_ctrl.set_counts = 0;
+            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_data;
         }
-        case fifo_ctrl_action_pop_capture_data: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_data;
-            fifo_ctrl_state.data[0] <= data0[32;0];
-            fifo_ctrl_state.data[1] <= data0[32;32];
-            fifo_ctrl_state.data[2] <= data1[32;0];
-            fifo_ctrl_state.data[3] <= data1[32;32];
-            fifo_ctrl_state.data[4] <= data2[32;0];
-            fifo_ctrl_state.data[5] <= data2[32;32];
-            fifo_ctrl_state.data[6] <= data3[32;0];
-            fifo_ctrl_state.data[7] <= data3[32;32];
-        }
-        case fifo_ctrl_action_read_data: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_data_gap;
-            fifo_ctrl_data.bytes_valid <= fifo_ctrl_combs.read_data_bytes_valid;
-            fifo_ctrl_data.data <= fifo_ctrl_state.data[0];
-        }
-        case fifo_ctrl_action_read_data_gap: {
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_data;
-            fifo_ctrl_state.count <= fifo_ctrl_state.count - 4;
-            for (i;7) {
-                fifo_ctrl_state.data[i] <= fifo_ctrl_state.data[i+1];
-            }
-        }
-        case fifo_ctrl_action_read_data_gap_last_more_words: {
-            fifo_ctrl_state.count <= fifo_ctrl_state.byte_count;
-            fifo_ctrl_state.word_count <= fifo_ctrl_state.word_count - 1;
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_req_pop;
-        }
-        case fifo_ctrl_action_read_data_gap_last: {
+        case fifo_ctrl_action_take_last_data: {
             fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_op;
         }
-        case fifo_ctrl_action_complete_okay: {
-            fifo_ctrl_data.bytes_valid <= 0;
-            fifo_ctrl_data.data <= 0;
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_idle;
+        case fifo_ctrl_action_take_next_data: {
+            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_request_next_data;
         }
-        case fifo_ctrl_action_complete_poll_failed: {
-            fifo_ctrl_data.bytes_valid <= 0;
-            fifo_ctrl_data.data <= 0;
-            fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_idle;
-        }
-        case fifo_ctrl_action_complete_errored: {
-            fifo_ctrl_data.bytes_valid <= 0;
-            fifo_ctrl_data.data <= 0;
+        case fifo_ctrl_action_complete: {
+            fifo_ctrl_combs.completed = 1;
             fifo_ctrl_state.fsm_state <= fifo_ctrl_fsm_idle;
         }
         case fifo_ctrl_action_none: {
             fifo_ctrl_state.fsm_state <= fifo_ctrl_state.fsm_state;
         }
         }
-        pop_fifo = fifo_ctrl_combs.pop_fifo;
-        if (fifo_ctrl_state.fsm_state !=fifo_ctrl_fsm_idle) {
-            fifo_ctrl_state.fifo_status <= fifo_status;
-        }
+    }
+
+    /*b Instantiate Fifo sink */
+    instantiate_fifo: {
+        fifo_sink sink( clk <- clk, reset_n <= reset_n,
+                        fifo_sink_ctrl <= fifo_sink_ctrl,
+                        fifo_resp => fifo_resp,
+                        fifo_status <= fifo_status,
+                        data_valid <= data_valid,
+                        data0 <= data0,
+                        data1 <= data1,
+                        data2 <= data2,
+                        data3 <= data3,
+                        data4 <= data4,
+                        pop_fifo => pop_fifo,
+                        pop_rdy <= pop_rdy
+            );
     }
 
     /*b All done */

--- a/cdl/dbg_master_fifo_sink.cdl
+++ b/cdl/dbg_master_fifo_sink.cdl
@@ -166,6 +166,7 @@ module dbg_master_fifo_sink( clock clk,
                              input bit[64] data1,
                              input bit[64] data2,
                              input bit[64] data3,
+                             input bit[64] data4,
                              input bit pop_rdy "Must be independent of pop_fifo output, indicates a pop_fifo would be taken",
                              output bit pop_fifo "Must be deasserted if a pop is taken but data_valid is not asserted; can be reasserted once data_valid has become asserted"
     )

--- a/cdl/dbg_master_fifo_sink.cdl
+++ b/cdl/dbg_master_fifo_sink.cdl
@@ -20,6 +20,7 @@
  */
 /*a Includes */
 include "debug.h"
+include "fifo_sink.h"
 include "fifo_status.h"
 
 /*a Types */

--- a/cdl/debug_modules.h
+++ b/cdl/debug_modules.h
@@ -38,13 +38,14 @@ module dbg_master_fifo_sink( clock clk,
                              input bit[64] data1,
                              input bit[64] data2,
                              input bit[64] data3,
+                             input bit[64] data4,
                              input bit pop_rdy "Must be independent of pop_fifo output, indicates a pop_fifo would be taken",
                              output bit pop_fifo
     )
 {
     timing to   rising clock clk dbg_master_req;
     timing from rising clock clk dbg_master_resp;
-    timing to   rising clock clk fifo_status, data0, data1, data2, data3, data_valid, pop_rdy;
+    timing to   rising clock clk fifo_status, data0, data1, data2, data3, data4, data_valid, pop_rdy;
     timing from rising clock clk pop_fifo;
 }
 

--- a/cdl/fifo_modules.h
+++ b/cdl/fifo_modules.h
@@ -1,4 +1,5 @@
 include "fifo_sink.h"
+include "fifo_status.h"
 extern module fifo_sink( clock clk,
                              input bit reset_n    "Active low reset",
                              input t_fifo_sink_ctrl fifo_sink_ctrl,

--- a/cdl/fifo_modules.h
+++ b/cdl/fifo_modules.h
@@ -1,3 +1,26 @@
+include "fifo_sink.h"
+extern module fifo_sink( clock clk,
+                             input bit reset_n    "Active low reset",
+                             input t_fifo_sink_ctrl fifo_sink_ctrl,
+                             output t_fifo_sink_response fifo_resp,
+                             input t_fifo_status fifo_status,
+                             input bit data_valid "May occur in the same cycle as pop_fifo & pop_rdy OR later; can often be tied to !empty",
+                             input bit[64] data0,
+                             input bit[64] data1,
+                             input bit[64] data2,
+                             input bit[64] data3,
+                             input bit[64] data4,
+                             input bit pop_rdy "Must be independent of pop_fifo output, indicates a pop_fifo would be taken",
+                             output bit pop_fifo "Must be deasserted if a pop is taken but data_valid is not asserted; can be reasserted once data_valid has become asserted"
+    )
+{
+    timing to   rising clock clk fifo_sink_ctrl, fifo_status;
+    timing to   rising clock clk data_valid, pop_rdy;
+    timing to   rising clock clk data0, data1, data2, data3, data4;
+    timing from rising clock clk fifo_resp;
+    timing from rising clock clk pop_fifo;
+}
+
 extern module byte_fifo_multiaccess_24_8( clock clk                            "Clock for logic",
                                      input bit reset_n                    "Active low reset",
 

--- a/cdl/fifo_sink.cdl
+++ b/cdl/fifo_sink.cdl
@@ -1,25 +1,6 @@
-/** @copyright (C) 2024,  Gavin J Stark.  All rights reserved.
- *
- * @copyright
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *     http://www.apache.org/licenses/LICENSE-2.0.
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
- * @file   dbg_master_fifo_sink.cdl
- * @brief  Simple 'debug master' that sinks data out of a FIFO
- *
- * CDL implementation of a debug 'master' that sinks data out of an
- * arbitrary FIFO
- *
- */
 /*a Includes */
 include "debug.h"
+include "fifo_sink.h"
 include "fifo_status.h"
 
 /*a Types */
@@ -62,40 +43,6 @@ typedef fsm {
         fifo_ctrl_fsm_idle
     }     "Data is being presented, and can move to next (sub)transaction";
 } t_fifo_ctrl_fsm_state;
-
-/*t t_fifo_sink_action
- *
- * Action that the FIFO ctrl is taking, based on the FSM state and the opcode etc
- */
-typedef enum [2] {
-    fifo_sink_action_idle,
-    fifo_sink_action_get_status,
-    fifo_sink_action_read_data
-} t_fifo_sink_action;
-
-/*t t_fifo_sink_ctrl
- *
- * Control of the Fifo sink
- */
-typedef struct {
-    t_fifo_sink_action action;
-    bit set_counts;
-    bit[6] byte_count;
-    bit[16] word_count;
-} t_fifo_sink_ctrl;
-
-/*t t_fifo_sink_response
- *
- * Control of the Fifo sink
- */
-typedef struct {
-    bit valid;
-    bit last_word;
-    bit last_byte_of_word;
-    bit empty;
-    bit[3] bytes_valid;
-    bit[32] data;
-} t_fifo_sink_response;
 
 /*t t_ctrl_state
  *

--- a/cdl/fifo_sink.cdl
+++ b/cdl/fifo_sink.cdl
@@ -1,0 +1,358 @@
+/** @copyright (C) 2024,  Gavin J Stark.  All rights reserved.
+ *
+ * @copyright
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * @file   dbg_master_fifo_sink.cdl
+ * @brief  Simple 'debug master' that sinks data out of a FIFO
+ *
+ * CDL implementation of a debug 'master' that sinks data out of an
+ * arbitrary FIFO
+ *
+ */
+/*a Includes */
+include "debug.h"
+include "fifo_status.h"
+
+/*a Types */
+/*t t_fifo_ctrl_action
+ *
+ * Action that the FIFO FSM ctrl is taking, based on the FSM state and the opcode etc
+ */
+typedef enum [4] {
+    fifo_ctrl_action_none,
+    fifo_ctrl_action_read_status,
+    fifo_ctrl_action_read_empty,
+    fifo_ctrl_action_read_next_data,
+    fifo_ctrl_action_capture_pop_req,
+    fifo_ctrl_action_wait_for_pop_data_valid,
+    fifo_ctrl_action_pop_capture_data,
+    fifo_ctrl_action_completed
+} t_fifo_ctrl_action;
+
+/*t t_fifo_ctrl_fsm_state
+ *
+ * Fifo_Ctrl FSM states
+ */
+typedef fsm {
+    fifo_ctrl_fsm_idle  {
+        fifo_ctrl_fsm_idle,
+        fifo_ctrl_fsm_completed,
+        fifo_ctrl_fsm_data
+    }     "Waiting for a byte-code op - or end of data";
+    fifo_ctrl_fsm_req_pop {
+        fifo_ctrl_fsm_wait_for_pop_data_valid,
+        fifo_ctrl_fsm_data
+    }     "Requesting pop of data";
+    fifo_ctrl_fsm_wait_for_pop_data_valid {
+        fifo_ctrl_fsm_data
+    }     "Requested pop of data, waiting for data valid";
+    fifo_ctrl_fsm_data {
+        fifo_ctrl_fsm_completed
+    }     "Data has become valid";
+    fifo_ctrl_fsm_completed {
+        fifo_ctrl_fsm_idle
+    }     "Data is being presented, and can move to next (sub)transaction";
+} t_fifo_ctrl_fsm_state;
+
+/*t t_fifo_sink_action
+ *
+ * Action that the FIFO ctrl is taking, based on the FSM state and the opcode etc
+ */
+typedef enum [2] {
+    fifo_sink_action_idle,
+    fifo_sink_action_get_status,
+    fifo_sink_action_read_data
+} t_fifo_sink_action;
+
+/*t t_fifo_sink_ctrl
+ *
+ * Control of the Fifo sink
+ */
+typedef struct {
+    t_fifo_sink_action action;
+    bit set_counts;
+    bit[6] byte_count;
+    bit[16] word_count;
+} t_fifo_sink_ctrl;
+
+/*t t_fifo_sink_response
+ *
+ * Control of the Fifo sink
+ */
+typedef struct {
+    bit valid;
+    bit last_word;
+    bit last_byte_of_word;
+    bit empty;
+    bit[3] bytes_valid;
+    bit[32] data;
+} t_fifo_sink_response;
+
+/*t t_ctrl_state
+ *
+ * State for the ROM side of the fifo_ctrl - effectively program
+ * counter and the data read from the ROM - plus an indication that
+ * the fifo_ctrl is idle.
+ *
+ * Fifo_Ctrl execution state; FSM and APB address, accumulator and repeat count
+ */
+typedef struct {
+    t_fifo_ctrl_fsm_state fsm_state   "Fifo_Ctrl FSM state machine state";
+    bit[6] bytes_remaining;
+    bit[6] byte_count;
+    bit[16] word_count;
+    bit[32][10] data;
+} t_ctrl_state;
+
+/*t t_ctrl_combs
+ *
+ * Combinatorial signals decoded from the @a script_state - basically the ROM read request
+ *
+ * Combinatorial decode of the script state, used to control the ROM state and the APB state machine
+ */
+typedef struct {
+    t_fifo_ctrl_action action        "Action that the script should take";
+
+    bit pop_fifo;
+} t_ctrl_combs;
+
+/*t t_fifo_ctrl_data
+ *
+ * Data to be returned in the dbg response
+ */
+typedef struct {
+    bit[32] data;
+    bit[3] bytes_valid;
+} t_fifo_ctrl_data;
+
+/*a Module */
+module fifo_sink( clock clk,
+                             input bit reset_n    "Active low reset",
+                             input t_fifo_sink_ctrl fifo_sink_ctrl,
+                             output t_fifo_sink_response fifo_resp,
+                             input t_fifo_status fifo_status,
+                             input bit data_valid "May occur in the same cycle as pop_fifo & pop_rdy OR later; can often be tied to !empty",
+                             input bit[64] data0,
+                             input bit[64] data1,
+                             input bit[64] data2,
+                             input bit[64] data3,
+                             input bit[64] data4,
+                             input bit pop_rdy "Must be independent of pop_fifo output, indicates a pop_fifo would be taken",
+                             output bit pop_fifo "Must be deasserted if a pop is taken but data_valid is not asserted; can be reasserted once data_valid has become asserted"
+    )
+"""
+
+This module provides simple 'pop' and 'status' access to a FIFO in a
+manner that can be used by APB or dbg targets
+
+It takes an action that is either 'get_status' or 'read_data'.
+
+For getting the status, a 32-bit data value is prepared and presented
+on the following cycle, with data_valid and 4 bytes valid.
+
+For reading data, a number of bytes-per-FIFO-data and words-of-FIFO
+are given on the *first* read (with set_counts asserted).
+
+* If the FIFO is empty then a valid data response is presented with zero bytes of data valid.
+
+* If the FIFO is not empty then pop_fifo will be asserted; when
+  pop_rdy is also asserted in the same cycle the pop_fifo will be
+  deasserted in the next cycle (so pop_rdy can be tied high for simple
+  scenarios); in the same cycle as pop_rdy, or in a *later* cycle, the
+  data_valid should be asserted with valid data popped from the
+  FIFO. (At this point the status should be updated to reflect the
+  pop).
+
+* When data has been read from the FIFO it is stored in internal
+  registers; it is presented up to 4-bytes per cycle. If the last data
+  of the last word is being presented then 'last' will be asserted
+  too.
+
+* Data is automatically fetched for repeated reads - 
+
+"""
+{
+    /*b Clock and reset */
+    default clock clk;
+    default reset active_low reset_n;
+
+    comb t_ctrl_combs     ctrl_combs       "Combinatorial decode FSM state";
+    clocked t_ctrl_state  ctrl_state={*=0} "State of the FSM etc";
+
+    clocked t_fifo_sink_response fifo_resp = {*=0};
+
+    /*b Fifo state machine */
+    fifo_state_machine """
+    State machine for the FIFO interface
+    """: {
+
+        /*b Defaults */
+        ctrl_combs.action = fifo_ctrl_action_none;
+        ctrl_combs.pop_fifo = 0;
+
+        /*b Determine script action */
+        full_switch (ctrl_state.fsm_state) {
+        case fifo_ctrl_fsm_idle: {
+            full_switch (fifo_sink_ctrl.action) {
+            case fifo_sink_action_get_status:  {
+                ctrl_combs.action = fifo_ctrl_action_read_status;
+            }
+            case fifo_sink_action_read_data: {
+                if (ctrl_state.bytes_remaining != 0) {
+                    ctrl_combs.action = fifo_ctrl_action_read_next_data;
+                } elsif (fifo_status.empty) {
+                    ctrl_combs.action = fifo_ctrl_action_read_empty;
+                } else {
+                    ctrl_combs.action = fifo_ctrl_action_capture_pop_req;
+                }
+            }
+            default: {
+                ctrl_combs.action = fifo_ctrl_action_none;
+            }
+            }
+        }
+        case fifo_ctrl_fsm_req_pop: {
+            ctrl_combs.pop_fifo = 1;
+            if (pop_rdy) {
+                ctrl_combs.action = fifo_ctrl_action_wait_for_pop_data_valid;
+                if (data_valid) {
+                    ctrl_combs.action = fifo_ctrl_action_pop_capture_data;
+                }
+            }
+        }
+        case fifo_ctrl_fsm_wait_for_pop_data_valid: {
+            if (data_valid) {
+                ctrl_combs.action = fifo_ctrl_action_pop_capture_data;
+            }
+        }
+        case fifo_ctrl_fsm_data: {
+            ctrl_combs.action = fifo_ctrl_action_read_next_data;
+        }
+        case fifo_ctrl_fsm_completed: {
+            ctrl_combs.action = fifo_ctrl_action_completed;
+        }
+        }
+        pop_fifo = ctrl_combs.pop_fifo;
+    }
+
+    /*b Fifo FSM action handling */
+    fsm_actions """
+    Perform the actions of the state machine
+    """: {
+        fifo_resp.bytes_valid <= 0;
+        full_switch (ctrl_combs.action) {
+        case fifo_ctrl_action_completed: {
+            // Completed a transaction, and data is valid in the
+            // response in *this* cycle
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_idle;
+        }
+        case fifo_ctrl_action_read_status: {
+            // Fifo status is valid and must be presented in the next
+            // cycle
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_completed;
+            fifo_resp.valid <= 1;
+            fifo_resp.bytes_valid <= 4;
+            fifo_resp.empty <= fifo_status.empty;
+            fifo_resp.last_word <= 1;
+            fifo_resp.last_byte_of_word <= 1;
+            fifo_resp.data <=  bundle( fifo_status.spaces_available[14;0],
+                                            fifo_status.entries_full[14;0],
+                                            fifo_status.overflowed,
+                                            fifo_status.underflowed,
+                                            fifo_status.full,
+                                            fifo_status.empty );
+            if (fifo_status.spaces_available >= 0x4000) {
+                fifo_resp.data[14;18] <= -1;
+            }
+            if (fifo_status.entries_full >= 0x4000) {
+                fifo_resp.data[14;4] <= -1;
+            }
+        }
+        case fifo_ctrl_action_capture_pop_req: {
+            // In next state drive 'pop_fifo' and wait for 'pop_rdy'
+            //
+            // Capture the length of data now
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_req_pop;
+            ctrl_state.bytes_remaining <= ctrl_state.byte_count;
+            if (fifo_sink_ctrl.set_counts) {
+                ctrl_state.byte_count <= fifo_sink_ctrl.byte_count;
+                ctrl_state.bytes_remaining <= fifo_sink_ctrl.byte_count;
+                ctrl_state.word_count <= fifo_sink_ctrl.word_count;
+            }
+        }
+        case fifo_ctrl_action_wait_for_pop_data_valid: {
+            // Asserting 'pop_fifo' and 'pop_rdy' is asserted, but 'data_valid' is not
+            //
+            // Move to stop driving 'pop_fifo' but wait for 'data_valid'
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_wait_for_pop_data_valid;
+        }
+        case fifo_ctrl_action_pop_capture_data: {
+            // 'data_valid' is asserted in response to a 'pop_fifo'
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_data;
+            ctrl_state.data[0] <= data0[32;0];
+            ctrl_state.data[1] <= data0[32;32];
+            ctrl_state.data[2] <= data1[32;0];
+            ctrl_state.data[3] <= data1[32;32];
+            ctrl_state.data[4] <= data2[32;0];
+            ctrl_state.data[5] <= data2[32;32];
+            ctrl_state.data[6] <= data3[32;0];
+            ctrl_state.data[7] <= data3[32;32];
+            ctrl_state.data[8] <= data4[32;0];
+            ctrl_state.data[9] <= data4[32;32];
+        }
+        case fifo_ctrl_action_read_next_data: {
+            // Data in the state is valid and must be presented in the next
+            // cycle
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_completed;
+            fifo_resp.valid <= 1;
+            fifo_resp.data <= ctrl_state.data[0];
+            fifo_resp.empty <= 0;
+            fifo_resp.last_word <= 0;
+            fifo_resp.last_byte_of_word <= 0;
+            if (ctrl_state.bytes_remaining <= 4) {
+                fifo_resp.bytes_valid <= ctrl_state.bytes_remaining[3;0];
+                fifo_resp.last_byte_of_word <= 1;
+                if (ctrl_state.word_count <= 1) {
+                    fifo_resp.last_word <= 1;
+                }
+            } else {
+                fifo_resp.bytes_valid <= 4;
+            }
+ 
+            for (i;7) {
+                ctrl_state.data[i] <= ctrl_state.data[i+1];
+            }
+            if (ctrl_state.bytes_remaining <= 4) {
+                ctrl_state.bytes_remaining <= 0;
+                ctrl_state.word_count <= ctrl_state.word_count - 1;
+            } else {
+                ctrl_state.bytes_remaining <= ctrl_state.bytes_remaining - 4;
+            }
+        }
+        case fifo_ctrl_action_read_empty: {
+            // Fifo empty when asking for a read; no data to present,
+            // but it must be presented in the next cycle
+            ctrl_state.fsm_state <= fifo_ctrl_fsm_completed;
+            fifo_resp.valid <= 1;
+            fifo_resp.empty <= 1;
+            fifo_resp.last_word <= 1;
+            fifo_resp.last_byte_of_word <= 1;
+        }
+        case fifo_ctrl_action_none: {
+            ctrl_state.fsm_state <= ctrl_state.fsm_state;
+        }
+        }
+
+    }
+
+    /*b All done */
+}

--- a/cdl/fifo_sink.cdl
+++ b/cdl/fifo_sink.cdl
@@ -195,6 +195,7 @@ are given on the *first* read (with set_counts asserted).
     fsm_actions """
     Perform the actions of the state machine
     """: {
+        fifo_resp.valid <= 0;
         fifo_resp.bytes_valid <= 0;
         full_switch (ctrl_combs.action) {
         case fifo_ctrl_action_completed: {
@@ -231,9 +232,9 @@ are given on the *first* read (with set_counts asserted).
             ctrl_state.fsm_state <= fifo_ctrl_fsm_req_pop;
             ctrl_state.bytes_remaining <= ctrl_state.byte_count;
             if (fifo_sink_ctrl.set_counts) {
-                ctrl_state.byte_count <= fifo_sink_ctrl.byte_count;
-                ctrl_state.bytes_remaining <= fifo_sink_ctrl.byte_count;
-                ctrl_state.word_count <= fifo_sink_ctrl.word_count;
+                ctrl_state.byte_count <= fifo_sink_ctrl.byte_count + 1;
+                ctrl_state.bytes_remaining <= fifo_sink_ctrl.byte_count + 1;
+                ctrl_state.word_count <= fifo_sink_ctrl.word_count + 1;
             }
         }
         case fifo_ctrl_action_wait_for_pop_data_valid: {
@@ -290,6 +291,7 @@ are given on the *first* read (with set_counts asserted).
             // but it must be presented in the next cycle
             ctrl_state.fsm_state <= fifo_ctrl_fsm_completed;
             fifo_resp.valid <= 1;
+            fifo_resp.bytes_valid <= 0;
             fifo_resp.empty <= 1;
             fifo_resp.last_word <= 1;
             fifo_resp.last_byte_of_word <= 1;

--- a/cdl/fifo_sink.h
+++ b/cdl/fifo_sink.h
@@ -1,0 +1,35 @@
+/*a Types */
+/*t t_fifo_sink_action
+ *
+ * Action that the FIFO ctrl is taking, based on the FSM state and the opcode etc
+ */
+typedef enum [2] {
+    fifo_sink_action_idle,
+    fifo_sink_action_get_status,
+    fifo_sink_action_read_data
+} t_fifo_sink_action;
+
+/*t t_fifo_sink_ctrl
+ *
+ * Control of the Fifo sink
+ */
+typedef struct {
+    t_fifo_sink_action action;
+    bit set_counts;
+    bit[6] byte_count;
+    bit[16] word_count;
+} t_fifo_sink_ctrl;
+
+/*t t_fifo_sink_response
+ *
+ * Control of the Fifo sink
+ */
+typedef struct {
+    bit valid;
+    bit last_word;
+    bit last_byte_of_word;
+    bit empty;
+    bit[3] bytes_valid;
+    bit[32] data;
+} t_fifo_sink_response;
+

--- a/library_desc.py
+++ b/library_desc.py
@@ -84,6 +84,8 @@ class DprintfModules(cdl_desc.Modules):
                                            },
                            cdl_filename="generic_valid_ack_sram_fifo") ]
 
+    modules += [ CdlModule("fifo_sink") ]
+
     modules += [ CdlModule("dbg_master_mux") ]
     modules += [ CdlModule("dbg_master_fifo_sink") ]
     modules += [ CdlModule("dbg_master_sram_access") ]

--- a/python/utils/fifo_status.py
+++ b/python/utils/fifo_status.py
@@ -21,7 +21,7 @@ class FifoStatus:
         self.empty = self.entries_full == 0
         self.full = self.entries_full == self.size
         pass        
-    def as_dbg_master_fifo_status(self) -> int:
+    def as_csr32(self) -> int:
         r = 0
         if self.empty: r += 1
         if self.full: r += 2
@@ -40,6 +40,8 @@ class FifoStatus:
             r += (self.spaces_available & 0x3fff) << 18
             pass
         return r
+    def as_dbg_master_fifo_status(self) -> int:
+        return self.as_csr32()
     def push(self):
         if self.full:
             self.overflowed = True

--- a/tb_cdl/tb_dbg_dprintf_fifo.cdl
+++ b/tb_cdl/tb_dbg_dprintf_fifo.cdl
@@ -109,6 +109,7 @@ module tb_dbg_dprintf_fifo( clock clk,
                                   data1 <= dprintf_fifo_out_req.data_1,
                                   data2 <= dprintf_fifo_out_req.data_2,
                                   data3 <= dprintf_fifo_out_req.data_3,
+                                  data4 <= bundle(48b0, dprintf_fifo_out_req.address),
                                   pop_rdy <= dbg_pop_rdy,
                                   data_valid <= dprintf_fifo_out_data_valid & !dprintf_fifo_status.empty,
                                   pop_fifo => dbg_pop_fifo

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ CDL_REGRESS = ${CDL_ROOT}/libexec/cdl/cdl_regress.py
 
 SMOKE_OPTIONS ?= --only-tests 'smoke'
 SMOKE_TESTS   ?= test_dprintf test_clock_divider test_fifo test_byte_fifo_multiaccess test_dbg_dprintf
-SMOKE_TESTS   ?= test_async
+SMOKE_TESTS   ?= test_dbg_dprintf
 REGRESS_TESTS ?= test_async test_byte_fifo_multiaccess test_clock_divider test_dprintf test_fifo test_dbg_dprintf
 CDL_REGRESS_PACKAGE_DIRS = --package-dir regress:${SRC_ROOT}/python  --package-dir regress:${GRIP_ROOT_PATH}/atcf_hardware_utils/python --package-dir regress:${GRIP_ROOT_PATH}/atcf_hardware_apb/python
 

--- a/test/python/test_dbg_dprintf.py
+++ b/test/python/test_dbg_dprintf.py
@@ -25,6 +25,7 @@ from cdl.sim     import HardwareThDut
 from cdl.sim     import TestCase
 from typing import Optional
 
+#a FifoScript
 #c FifoScript
 class FifoScript(DbgMasterMuxScript):
     select = 1
@@ -43,6 +44,7 @@ class SramScript(DbgMasterMuxScript):
         pass
     pass
 
+#a DprintfTest
 #c DprintfTest_Base
 class DprintfTest_Base(ThExecFile):
     th_name = "Utils dprintf test harness"
@@ -179,7 +181,7 @@ class DprintfTest_0(DprintfTest_Base):
          FifoStatus(515,1).as_dbg_master_fifo_status(),
          ]
         ),
-       ("Read two entries of 64 bits of FIFO data (abcdefgh), only one of which is present",
+       ("Read two entries of 64 bits of FIFO data (abcdefgh), only one of which is present; should poll failed",
         [],
         [],
         FifoScript([("read",64,2), "status"]),


### PR DESCRIPTION
Add a fifo_sink module that reads data and status from a FIFO

This allows a common mechanism for dbg script and APB to take data from a FIFO